### PR TITLE
Fix broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,4 +296,4 @@ Happily, we now have several contributors working on the project, and we welcome
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=kangpeilun/VastGaussian&type=date&legend=top-left)](https://www.star-history.com/#kangpeilun/VastGaussian&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=kangpeilun/VastGaussian&type=date&legend=top-left)](https://star-history.dera.page/#kangpeilun/VastGaussian&type=date&legend=top-left)


### PR DESCRIPTION
The Star History chart in the README is currently broken and not rendering, because of restrictions on the GitHub stargazer API. This change updates the chart link to a working alternative so the star history displays correctly again.